### PR TITLE
bugfix/room-creation-auth-and-cleanup

### DIFF
--- a/utils/formatDateAndTime.js
+++ b/utils/formatDateAndTime.js
@@ -1,0 +1,81 @@
+export const formatDate = (date, locale = "he-IL", options = {}) => {
+  return new Date(date).toLocaleDateString(locale, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+    ...options,
+  });
+};
+
+export const formatTime = (date, locale = "he-IL", options = {}) => {
+  return new Date(date).toLocaleTimeString(locale, {
+    hour: "2-digit",
+    minute: "2-digit",
+    ...options,
+  });
+};
+
+export const formatDateAndTime = (
+  date,
+  locale = "he-IL",
+  dateOptions = {},
+  timeOptions = {}
+) => {
+  const d = new Date(date);
+
+  const formattedDate = d.toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+    ...dateOptions,
+  });
+
+  const formattedTime = d.toLocaleTimeString(locale, {
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+    ...timeOptions,
+  });
+
+  return `${formattedDate} ${formattedTime}`;
+};
+
+export const timeAgo = (date) => {
+  const seconds = Math.floor((Date.now() - new Date(date)) / 1000);
+
+  const intervals = [
+    { label: "year", seconds: 31536000 },
+    { label: "month", seconds: 2592000 },
+    { label: "day", seconds: 86400 },
+    { label: "hour", seconds: 3600 },
+    { label: "minute", seconds: 60 },
+    { label: "second", seconds: 1 },
+  ];
+
+  for (const { label, seconds: s } of intervals) {
+    const count = Math.floor(seconds / s);
+    if (count >= 1) return `${count} ${label}${count > 1 ? "s" : ""} ago`;
+  }
+
+  return "just now";
+};
+
+export const isToday = (date) => {
+  const d = new Date(date);
+  const now = new Date();
+  return (
+    d.getDate() === now.getDate() &&
+    d.getMonth() === now.getMonth() &&
+    d.getFullYear() === now.getFullYear()
+  );
+};
+
+export const addDays = (date, days) => {
+  const result = new Date(date);
+  result.setDate(result.getDate() + days);
+  return result;
+};
+
+export const subtractDays = (date, days) => {
+  return addDays(date, -days);
+};


### PR DESCRIPTION
fix: enforce proper room creation rules and clean payload

- Prevent non-admin users from creating rooms (requires JWT & matching admin ID)
- Stop sending frontend-generated default fields (e.g. isActive, players, etc.)
- Move all default values to backend to keep frontend payload minimal
- Add stricter token verification and cleaner request handling